### PR TITLE
Fix signin validation data nullables

### DIFF
--- a/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterSignInRequest.kt
+++ b/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterSignInRequest.kt
@@ -15,21 +15,23 @@
 
 package com.amazonaws.amplify.amplify_auth_cognito.types
 
+import androidx.annotation.NonNull
 import com.amazonaws.amplify.amplify_core.exception.ExceptionMessages
 import com.amazonaws.amplify.amplify_core.exception.InvalidRequestException
 import com.amplifyframework.auth.AuthUser
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignInOptions
 import com.amplifyframework.core.Amplify
 
 data class FlutterSignInRequest(val map: HashMap<String, *>) {
   val username: String = map["username"] as String;
   val password: String = map["password"] as String;
-  val options: AWSCognitoAuthSignInOptions = formatOptions(map["options"] as HashMap<String, *>)
+  val options: AWSCognitoAuthSignInOptions = formatOptions(map["options"] as HashMap<String, *>?)
 
-  private fun formatOptions(@NonNull rawOptions: HashMap<String, *>): AWSCognitoAuthSignInOptions {
+  private fun formatOptions(rawOptions: HashMap<String, *>?): AWSCognitoAuthSignInOptions {
     var options =  AWSCognitoAuthSignInOptions.builder();
 
-    if(rawOptions["validationData"] != null)
-      options.metadata(rawOptions["validationData"] as HashMap<String, String>);
+    if(rawOptions?.get("clientMetadata") != null)
+      options.metadata(rawOptions["clientMetadata"] as HashMap<String, String>);
 
     return options.build();
   }

--- a/packages/amplify_auth_cognito/ios/Classes/AuthCognitoBridge.swift
+++ b/packages/amplify_auth_cognito/ios/Classes/AuthCognitoBridge.swift
@@ -64,7 +64,8 @@ class AuthCognitoBridge {
     }
     
     func onSignIn(flutterResult: @escaping FlutterResult, request: FlutterSignInRequest) {
-        let options = AuthSignInRequest.Options(pluginOptions: request.options)
+        let pluginOptions = request.formatOptions(options: request.options)
+        let options = AuthSignInOperation.Request.Options(pluginOptions: pluginOptions)
 
         _ = Amplify.Auth.signIn(username: request.username, password:request.password, options: options) { response in
             switch response {

--- a/packages/amplify_auth_cognito/ios/Classes/FlutterSignInRequest.swift
+++ b/packages/amplify_auth_cognito/ios/Classes/FlutterSignInRequest.swift
@@ -14,6 +14,8 @@
  */
 
 import Foundation
+import AmplifyPlugins
+import AWSCore
 import amplify_core
 
 struct FlutterSignInRequest {
@@ -23,8 +25,15 @@ struct FlutterSignInRequest {
   init(dict: NSMutableDictionary){
     self.username = dict["username"] as! String?
     self.password = dict["password"] as! String?
-    self.options = dict["options"] as? Dictionary<String, Any>?
+    self.options = dict["options"] as! Dictionary<String, Any>?
   }
+    
+   func formatOptions(options: Dictionary<String, Any>?) -> AWSAuthSignInOptions {
+        return AWSAuthSignInOptions(
+            metadata: options?["clientMetadata"] as? [String : String]
+        )
+
+    }
 
   static func validate(dict: NSMutableDictionary) throws {
     let validationErrorMessage = "SignIn Request malformed."

--- a/packages/amplify_auth_cognito/lib/src/CognitoSignIn/CognitoSignInOptions.dart
+++ b/packages/amplify_auth_cognito/lib/src/CognitoSignIn/CognitoSignInOptions.dart
@@ -15,12 +15,16 @@
 
 import 'package:amplify_auth_plugin_interface/amplify_auth_plugin_interface.dart';
 class CognitoSignInOptions extends SignInOptions {
+  Map<String, String> validationData;
   Map<String, String> clientMetadata;
-  CognitoSignInOptions({this.clientMetadata}) : super();
+  CognitoSignInOptions({this.validationData, this.clientMetadata}) : super();
   Map<String, dynamic> serializeAsMap() {
     final Map<String, dynamic> pendingRequest = <String, dynamic>{};
     if (this.clientMetadata != null) {
-      pendingRequest["validationData"] = clientMetadata;
+      pendingRequest["clientMetadata"] = clientMetadata;
+    }
+    if (this.validationData != null) {
+      pendingRequest["validationData"] = validationData;
     }
     return pendingRequest;
   }

--- a/packages/amplify_auth_cognito/lib/src/CognitoSignIn/CognitoSignInOptions.dart
+++ b/packages/amplify_auth_cognito/lib/src/CognitoSignIn/CognitoSignInOptions.dart
@@ -15,16 +15,12 @@
 
 import 'package:amplify_auth_plugin_interface/amplify_auth_plugin_interface.dart';
 class CognitoSignInOptions extends SignInOptions {
-  Map<String, String> validationData;
   Map<String, String> clientMetadata;
-  CognitoSignInOptions({this.validationData, this.clientMetadata}) : super();
+  CognitoSignInOptions({this.clientMetadata}) : super();
   Map<String, dynamic> serializeAsMap() {
     final Map<String, dynamic> pendingRequest = <String, dynamic>{};
     if (this.clientMetadata != null) {
       pendingRequest["clientMetadata"] = clientMetadata;
-    }
-    if (this.validationData != null) {
-      pendingRequest["validationData"] = validationData;
     }
     return pendingRequest;
   }


### PR DESCRIPTION
How I tested:

```dart
      var platformMetadata = Platform.isAndroid ? 'Android-meta' : 'iOS-meta';

      var res = await Amplify.Auth.signIn(
          username: usernameController.text.trim(),
          password: passwordController.text.trim(),
          options: CognitoSignInOptions(
              clientMetadata: {'platform-metadata': platformMetadata})
      );
```

Writing the platform to the metadata made it easier to discern what I was looking at in the cloudwatch logs.